### PR TITLE
spotifyマーケット指定機能実装

### DIFF
--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -2,10 +2,11 @@
 class SongsController < ApplicationController
   def index
     service = SpotifySearchService.new
+  market = params[:market].presence || "JP"
     if params[:genre].present? && GenreHelper.valid_genre?(params[:genre])
-      @tracks = service.genre_search(params[:genre], 32)
+      @tracks = service.genre_search(params[:genre], 32, market)
     else
-      @tracks = service.random_search(32)
+      @tracks = service.random_search(32, market)
     end
   end
 end

--- a/app/helpers/market_helper.rb
+++ b/app/helpers/market_helper.rb
@@ -1,0 +1,18 @@
+module MarketHelper
+  # Spotify対応マーケット
+  def spotify_markets
+    [
+      ["JP", "Japan"],
+      ["US", "United States"],
+      ["GB", "United Kingdom"],
+      ["KR", "South Korea"],
+      ["DE", "Germany"],
+      ["FR", "France"],
+      ["BR", "Brazil"]
+    ]
+  end
+
+  def market_label(code)
+    spotify_markets.to_h[code] || code
+  end
+end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,6 +1,9 @@
 <header class="w-full bg-base-100 shadow p-4 flex items-center justify-between">
   <div class="text-2xl font-bold">CoverVibes</div>
-  <div class="flex items-center gap-2">
-    <%= render 'layouts/theme_switcher' %>
+  <div class="flex items-center gap-4">
+    <div class="flex items-center gap-2">
+  <%= render 'shared/market_selector' %>
+      <%= render 'layouts/theme_switcher' %>
+    </div>
   </div>
 </header>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -3,7 +3,7 @@
     <span class="font-bold text-xs text-gray-500 mb-1">Select Genre</span>
     <% GenreHelper.get_genre_list.each do |key, label| %>
       <% active = params[:genre] == key %>
-      <a href="/songs?genre=<%= key %>"
+      <a href="/songs?genre=<%= key %><%= params[:market].present? ? "&market=#{params[:market]}" : '' %>"
          class="btn btn-sm w-full <%= active ? 'btn-primary' : 'btn-outline' %>">
         <%= label %>
       </a>

--- a/app/views/shared/_market_selector.html.erb
+++ b/app/views/shared/_market_selector.html.erb
@@ -1,0 +1,22 @@
+<div x-data="{ open: false }" class="dropdown dropdown-end">
+  <button type="button" class="btn btn-sm btn-outline m-1 flex items-center gap-1" @click="open = !open">
+    <svg xmlns='http://www.w3.org/2000/svg' class='h-5 w-5' viewBox='0 0 20 20' fill='currentColor'><path d='M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z'/></svg>
+    <span>
+      <%= market_label(params[:market].presence || 'JP') %>
+    </span>
+  </button>
+  <ul x-show="open" @click.away="open = false" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-44 mt-2 z-50">
+    <% spotify_markets.each do |code, name| %>
+      <li>
+        <form action="<%= songs_path %>" method="get" class="w-full">
+          <% if params[:genre].present? %>
+            <input type="hidden" name="genre" value="<%= params[:genre] %>">
+          <% end %>
+          <button type="submit" name="market" value="<%= code %>" class="w-full text-left <%= (params[:market].presence || 'JP') == code ? 'btn-primary btn-sm' : '' %>">
+            <%= name %>
+          </button>
+        </form>
+      </li>
+    <% end %>
+  </ul>
+</div>


### PR DESCRIPTION
国指定で曲を絞り込めるように変更
デフォルトは日本
spotifyが対応する国コード US KR JP などでmarketを呼び出している